### PR TITLE
fix: Goのバージョンアップ go1.21 -> go1.23.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go_version: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x' ]
+        go_version: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x', '1.23.6' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
         run: go test -v -race -coverprofile=cover.os-${{ matrix.os }}.ver-${{ matrix.go_version }}.txt -covermode=atomic ./...
       - name: upload coverage
         uses: codecov/codecov-action@v3
-        if: ${{ matrix.go_version == '1.21.x' }}
+        if: ${{ matrix.go_version == '1.23.6' }}
         with:
           files: ./cover.os-${{ matrix.os }}.ver-${{ matrix.go_version }}.txt
   determine_release:
@@ -68,11 +68,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.6'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.21.x-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-1.23.6-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - uses: goreleaser/goreleaser-action@v2.9.1

--- a/analyzer/testdata/src/github.com/aereal/a/go.mod
+++ b/analyzer/testdata/src/github.com/aereal/a/go.mod
@@ -1,3 +1,3 @@
 module github.com/aereal/a
 
-go 1.21
+go 1.23.6

--- a/analyzer/testdata/src/github.com/aereal/b/go.mod
+++ b/analyzer/testdata/src/github.com/aereal/b/go.mod
@@ -1,3 +1,3 @@
 module github.com/aereal/b
 
-go 1.21
+go 1.23.6

--- a/analyzer/testdata/src/github.com/aereal/c/go.mod
+++ b/analyzer/testdata/src/github.com/aereal/c/go.mod
@@ -1,3 +1,3 @@
 module github.com/aereal/c
 
-go 1.21
+go 1.23.6

--- a/analyzer/testdata/src/github.com/aereal/d/go.mod
+++ b/analyzer/testdata/src/github.com/aereal/d/go.mod
@@ -1,3 +1,3 @@
 module github.com/aereal/d
 
-go 1.21
+go 1.23.6

--- a/analyzer/testdata/src/github.com/aereal/empty/go.mod
+++ b/analyzer/testdata/src/github.com/aereal/empty/go.mod
@@ -1,3 +1,3 @@
 module github.com/aereal/empty
 
-go 1.21
+go 1.23.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aereal/pkgboundaries
 
-go 1.21
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
- やりたいこと: 
  - goを1.23.6にバージョンアップをしたい
- やったこと: 
  - `go.mod` のバージョン修正
  - CIの修正
- 参考: https://github.com/aereal/pkgboundaries/pull/36